### PR TITLE
bug: 공고 리스트 셀 탭 인식 오류 수정

### DIFF
--- a/Targets/DesignSystem/Sources/Component/PostList/PostListCollectionView.swift
+++ b/Targets/DesignSystem/Sources/Component/PostList/PostListCollectionView.swift
@@ -10,7 +10,6 @@ import UIKit
 import DomainLayer
 
 import PinLayout
-import FlexLayout
 import RxSwift
 import RxCocoa
 

--- a/Targets/PresentationLayer/Sources/PostList/View/PostListViewController.swift
+++ b/Targets/PresentationLayer/Sources/PostList/View/PostListViewController.swift
@@ -174,8 +174,8 @@ private extension PostListViewController {
       .asSignal(onErrorJustReturn: [])
       .emit(with: self) { owner, posts in
         owner.collectionView.setupData(posts)
-        owner.collectionView.pin.sizeToFit()
-        owner.scrollView.contentSize.height = owner.collectionView.sizeThatFits(.zero).height + owner.postOrderControlView.frame.height
+        owner.contentView.flex.layout(mode: .adjustHeight)
+        owner.scrollView.contentSize.height = owner.contentView.frame.size.height
         owner.postOrderControlView.setCount(posts.count)
       }
       .disposed(by: disposeBag)


### PR DESCRIPTION
### 📌 관련 이슈 번호
- #66 

<br>

# 📘 작업 유형
 - [x] 버그 수정

<br>

# 📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
 - 공고 리스트 데이터가 업데이트되면 ScrollView 내부 ContentView의 height값도 업데이트 되도록 수정

<br>

### 📋 체크리스트 (PR을 올리기 전에 스스로 확인해봐요!)
 - PR 제목에 작업 내용을 요약하여 기재했는가?
 - 코딩컨벤션을 준수하는가?
 - 내 코드에 대해 스스로 검토를 했는가?

<br>

### 📝 특이 사항
해당 오류의 원인은 `PostListViewController`에서 `fetchPosts` Action을 통해 공고 리스트가 업데이트 되어 ScrollView의 height 값과 CollectionView의 Cell들이 업데이트 되었음에도, ScrollView 내부 ContentView의 height 값은 업데이트 되지 않아 터치 이벤트를 수신하지 못하는 것이었습니다.
따라서 공고 리스트가 업데이트 되면 ContentView의 height 값도 업데이트 되도록 수정했습니다.